### PR TITLE
[SPARK] Added extra condition to ensure Spark Job Name suffix is extracted

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -259,6 +259,8 @@ public class SaveIntoDataSourceCommandVisitor
       return Optional.ofNullable(command.options().get("kustotable"))
           .filter(Option::isDefined)
           .map(Option::get);
+    } else if (command.options().get("table").isDefined()) {
+      return Optional.of(command.options().get("table").get());
     } else if (command.dataSource() instanceof RelationProvider
         || command.dataSource() instanceof SchemaRelationProvider) {
       return ScalaConversionUtils.fromMap(command.options()).keySet().stream()


### PR DESCRIPTION
### Problem

When using the spark-3.3-bigquery library, the Spark Job name for the `execute_save_into_data_source_command` command will not include a suffix. This breaks the expected Spark Job naming spec consumers rely on.

Closes:

### Solution

This change modifies the `SaveIntoDatasourceCommandVisitor` class to check if the `table` property is defined and if so, go ahead and extract this information to use as the suffix.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project